### PR TITLE
Change array index name to fix csv import.

### DIFF
--- a/fileio/csv.php
+++ b/fileio/csv.php
@@ -40,7 +40,7 @@ class Red_Csv_File extends Red_FileIO {
 						'source' => trim( $csv[0] ),
 						'target' => trim( $csv[1] ),
 						'regex'  => $this->is_regex( $csv[0] ),
-						'group'  => $group,
+						'group_id'  => $group,
 						'match'  => 'url',
 						'red_action' => 'url'
 					) );


### PR DESCRIPTION
The current version throws the following Notice during a cvs import:

```
Undefined index: group_id in app/plugins/redirection/models/redirect.php on line 149
```

Even though the plugin indicates a successful import afterwards, no redirects are added.
This change fixes the direct problem, but it could be that there is a better place in the code to solve the actual issue.
